### PR TITLE
[FEAT] 배포 상태에 따른 슬랙 알림 메세지를 보냅니다.

### DIFF
--- a/.github/sendAlarm.yml
+++ b/.github/sendAlarm.yml
@@ -1,0 +1,100 @@
+#변경해야 될 부분이 있습니다. ctrl+f로 "변경"을 찾아보세요.
+name: Alert Deploy Status
+
+on:
+  pull_request:
+    types: ['closed']
+
+# job is triggered only when PR is closed and merged to the 'main' branch
+jobs:
+  prepare_alert_deploy_status:
+    if: github.event.pull_request.merged == true && github.event.pull_request.base.ref == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: prepare for a slack-send environment
+        id: slack
+        uses: slackapi/slack-github-action@v1.23.0
+        with:
+          payload: |
+            {
+              "channel": "#test-for-github-action", "username": "Alert Manager", "text": "*===UPDATE ALARM===*", "icon_emoji": ":seal:"
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      
+  #########################################
+  ### 변경: 여기에 docker job을 넣어주세요 ##
+  #########################################
+
+  alert_deploy_failed:
+    if: ${{ failure() }} # 이전의 job이 실패했을 경우 실행됨
+    needs: prepare_alert_deploy_status # docker job의 이름으로 변경해야됨
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: prepare to get github repo url
+        run: |
+          sudo apt install jq
+
+      # Parse PR
+      - name: get Pull Request Title
+        id: pr_info
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "pull_request_number=${{ github.event.number }}" >> $GITHUB_OUTPUT
+          echo "pull_request_title=${{ github.event.pull_request.title }}" >> $GITHUB_OUTPUT
+
+      - name: Failed to send a slack alarm
+        shell: bash
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          GITHUB_REPO: ${{ toJson(github) }}
+        run: |  
+          GITHUB_REPO_URL_w=$(echo $GITHUB_REPO | jq '.repositoryUrl')
+          # "와 git:// 삭제
+          GITHUB_REPO_URL=$(echo "${GITHUB_REPO_URL_w:7:-1}")
+          
+          chmod +x tools/alertFailure.sh
+          tools/alertFailure.sh "$SLACK_WEBHOOK_URL" ${GITHUB_REPO_URL} "${{ steps.pr_info.outputs.pull_request_title }}"
+
+  alert_deploy_success:
+    if: ${{ success() }} # 이전의 job이 성공했을 경우 실행됨
+    runs-on: ubuntu-latest
+    needs: prepare_alert_deploy_status # docker job의 이름으로 변경해야됨
+    steps:
+      - uses: actions/checkout@v3
+      - name: prepare to get github repo url
+        run: |
+          sudo apt install jq
+
+      # Parse PR
+      - name: get Pull Request Title
+        id: pr_info
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "pull_request_number=${{ github.event.number }}" >> $GITHUB_OUTPUT
+          echo "pull_request_title=${{ github.event.pull_request.title }}" >> $GITHUB_OUTPUT
+
+      - name: Succeed to send a slack alarm
+        shell: bash
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          GITHUB_REPO: ${{ toJson(github) }}
+        run: |  
+          GITHUB_REPO_URL_w=$(echo $GITHUB_REPO | jq '.repositoryUrl')
+          # "와 git:// 삭제
+          GITHUB_REPO_URL=$(echo "${GITHUB_REPO_URL_w:7:-1}")
+
+          chmod +x tools/alertSuccess.sh
+          tools/alertSuccess.sh "$SLACK_WEBHOOK_URL" ${GITHUB_REPO_URL} "${{ steps.pr_info.outputs.pull_request_title }}"
+
+      # # Update README file
+      # - name: Update README.md
+      #   shell: bash
+      #   run: |
+      #     chmod +x updateReadme.sh
+      #     ./updateReadme.sh

--- a/tools/alertFailure.sh
+++ b/tools/alertFailure.sh
@@ -1,0 +1,12 @@
+# get current info
+SLACK_WEBHOOK_URL=$1
+REPO_URL=$2
+PR_CONTENT=$3
+
+MESSAGE="Deploy Failed!
+Tried to update: ${PR_CONTENT}
+Repo: ${REPO_URL}"
+
+echo $MESSAGE
+# 슬랙 채널로 메시지 요청
+curl -X POST --data-urlencode "payload={\"channel\": \"#test-for-github-action\", \"username\": \"Alert Manager\", \"text\": \"${MESSAGE}\", \"icon_emoji\": \":seal:\"}" $SLACK_WEBHOOK_URL

--- a/tools/alertSuccess.sh
+++ b/tools/alertSuccess.sh
@@ -1,0 +1,12 @@
+# get current info
+SLACK_WEBHOOK_URL=$1
+REPO_URL=$2
+PR_CONTENT=$3
+
+DAILY_MESSAGE="Deploy Success!
+Updated info: ${PR_CONTENT}
+Repo: ${REPO_URL}"
+
+echo $DAILY_MESSAGE
+# 슬랙 채널로 메시지 요청
+curl -X POST --data-urlencode "payload={\"channel\": \"#test-for-github-action\", \"username\": \"Alert Manager\", \"text\": \"${DAILY_MESSAGE}\", \"icon_emoji\": \":seal:\"}" $SLACK_WEBHOOK_URL


### PR DESCRIPTION
action file을 추가했습니다.
- 알림 조건: "PR이 closed되고, 'main' 브랜치로 merged 되었을 때"
- 알림 종류: 실패 / 성공 2가지
- 추가 설명: job을 3개로 분할